### PR TITLE
Make Preview Nicer

### DIFF
--- a/Camera/Base.lproj/Main.storyboard
+++ b/Camera/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15A282b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
@@ -99,31 +99,12 @@
                     <view key="view" contentMode="scaleToFill" id="wIb-Vp-0L8">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wfF-60-exu">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <animations/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <gestureRecognizers/>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="bVy-eS-xBu" appends="YES" id="PJB-w9-Qna"/>
-                                </connections>
-                            </view>
-                        </subviews>
                         <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
-                    <connections>
-                        <outlet property="previewView" destination="wfF-60-exu" id="MMB-jK-R4f"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zy6-hr-ood" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <panGestureRecognizer minimumNumberOfTouches="1" id="bVy-eS-xBu" userLabel="Preivew View Pan Gesture Recognizer">
-                    <connections>
-                        <action selector="panPreviewView:" destination="utw-gT-5h1" id="Vh9-E8-sUC"/>
-                    </connections>
-                </panGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="974.5" y="995.5"/>
         </scene>

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -12,7 +12,7 @@ import AVFoundation
 
 class PreviewViewController: UIViewController {
     
-    let newPreviewView = UIView()
+    let previewView = UIView()
     let blackView = UIView()
 
     let player = AVPlayer()
@@ -27,12 +27,12 @@ class PreviewViewController: UIViewController {
     override func viewWillAppear(animated: Bool) {
         
         self.view.backgroundColor = UIColor.clearColor()
-        newPreviewView.frame = self.view.bounds
-        view.insertSubview(newPreviewView, atIndex: 1)
-        newPreviewView.backgroundColor = UIColor.clearColor()
+        previewView.frame = self.view.bounds
+        view.insertSubview(previewView, atIndex: 1)
+        previewView.backgroundColor = UIColor.clearColor()
         
         panPreview = UIPanGestureRecognizer(target: self, action: "onPanPreview:")
-        newPreviewView.addGestureRecognizer(panPreview)
+        previewView.addGestureRecognizer(panPreview)
         
         let cameraRoll = returnContentsOfDocumentsDirectory()
         let latestItemInCameraRoll = String(cameraRoll.last!)
@@ -56,7 +56,7 @@ class PreviewViewController: UIViewController {
 //            let imageView = UIImageView(image: mirrorImage)
             
             imageView.frame = self.view.bounds
-            newPreviewView.addSubview(imageView)
+            previewView.addSubview(imageView)
             
         } else if latestFileFileExtension == ".mov" {
             
@@ -71,7 +71,7 @@ class PreviewViewController: UIViewController {
             playerLayer.player = player
             playerLayer.backgroundColor = UIColor.clearColor().CGColor
             playerLayer.videoGravity = AVLayerVideoGravityResize
-            newPreviewView.layer.addSublayer(playerLayer)
+            previewView.layer.addSublayer(playerLayer)
             player.play()
             
             NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerDidReachEndNotificationHandler:", name: "AVPlayerItemDidPlayToEndTimeNotification", object: player.currentItem)
@@ -99,19 +99,19 @@ class PreviewViewController: UIViewController {
         
         if sender.state == .Began {
             view.backgroundColor = UIColor.clearColor()
-            newPreviewView.backgroundColor = UIColor.clearColor()
+            previewView.backgroundColor = UIColor.clearColor()
             
             blackView.frame = self.view.bounds
             view.insertSubview(blackView, atIndex: 0)
         }
         if sender.state == .Changed {
             
-            newPreviewView.frame.origin.x = translation.x
-            newPreviewView.frame.origin.y = translation.y
+            previewView.frame.origin.x = translation.x
+            previewView.frame.origin.y = translation.y
             
             let rotation = convertValue(translation.x, r1Min: 0, r1Max: view.frame.width, r2Min: 0, r2Max: 10)
 
-            newPreviewView.transform = CGAffineTransformMakeDegreeRotation(rotation)
+            previewView.transform = CGAffineTransformMakeDegreeRotation(rotation)
             
             let makeTransparentOnPan = convertValue(abs(translation.y), r1Min: (view.frame.height / 8), r1Max: (view.frame.height / 2), r2Min: 0.8, r2Max: 0)
             
@@ -136,8 +136,8 @@ class PreviewViewController: UIViewController {
                 
                 UIView.animateWithDuration(dismissDuration, animations: { () -> Void in
                     
-                    self.newPreviewView.frame.origin.y = self.view.frame.height * 1.3
-                    self.newPreviewView.frame.origin.x += moveX
+                    self.previewView.frame.origin.y = self.view.frame.height * 1.3
+                    self.previewView.frame.origin.x += moveX
                     self.view.backgroundColor = UIColor(red: 1, green: 0, blue: 0, alpha: 1)
                     
                     }, completion: { (Bool) -> Void in
@@ -150,9 +150,9 @@ class PreviewViewController: UIViewController {
                         delay(0.1) {
                             self.player.pause()
                             self.playerLayer.removeFromSuperlayer()
-                            self.newPreviewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                            self.newPreviewView.subviews.forEach({ $0.removeFromSuperview() })
-                            self.newPreviewView.removeFromSuperview()
+                            self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                            self.previewView.subviews.forEach({ $0.removeFromSuperview() })
+                            self.previewView.removeFromSuperview()
                             self.blackView.removeFromSuperview()
                             self.view.backgroundColor = UIColor.clearColor()
                             self.view.removeFromSuperview()
@@ -164,8 +164,8 @@ class PreviewViewController: UIViewController {
                 
                 UIView.animateWithDuration(dismissDuration, animations: { () -> Void in
                     
-                    self.newPreviewView.frame.origin.y = (self.view.frame.height * 1.3) * -1
-                    self.newPreviewView.frame.origin.x += moveX
+                    self.previewView.frame.origin.y = (self.view.frame.height * 1.3) * -1
+                    self.previewView.frame.origin.x += moveX
                     self.view.backgroundColor = UIColor(red: 98/255, green: 217/255, blue: 98/255, alpha: 1)
                     
                     }, completion: { (Bool) -> Void in
@@ -173,9 +173,9 @@ class PreviewViewController: UIViewController {
                         delay(0.1) {
                             self.player.pause()
                             self.playerLayer.removeFromSuperlayer()
-                            self.newPreviewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                            self.newPreviewView.subviews.forEach({ $0.removeFromSuperview() })
-                            self.newPreviewView.removeFromSuperview()
+                            self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                            self.previewView.subviews.forEach({ $0.removeFromSuperview() })
+                            self.previewView.removeFromSuperview()
                             self.blackView.removeFromSuperview()
                             self.view.backgroundColor = UIColor.clearColor()
                             self.view.removeFromSuperview()
@@ -185,9 +185,9 @@ class PreviewViewController: UIViewController {
             } else {
                 UIView.animateWithDuration(0.3, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 10, options: [], animations: { () -> Void in
                     
-                    self.newPreviewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                    self.newPreviewView.frame.origin.x = 0
-                    self.newPreviewView.frame.origin.y = 0
+                    self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                    self.previewView.frame.origin.x = 0
+                    self.previewView.frame.origin.y = 0
                     
                     }, completion: { (Bool) -> Void in
                         

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -11,16 +11,28 @@ import AVKit
 import AVFoundation
 
 class PreviewViewController: UIViewController {
-
-    @IBOutlet weak var previewView: UIView!
     
+    let newPreviewView = UIView()
     let blackView = UIView()
+
+    let player = AVPlayer()
+    let playerLayer = AVPlayerLayer()
+    
+    var panPreview: UIPanGestureRecognizer!
     
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
     override func viewWillAppear(animated: Bool) {
+        
+        self.view.backgroundColor = UIColor.clearColor()
+        newPreviewView.frame = self.view.bounds
+        view.insertSubview(newPreviewView, atIndex: 1)
+        newPreviewView.backgroundColor = UIColor.clearColor()
+        
+        panPreview = UIPanGestureRecognizer(target: self, action: "onPanPreview:")
+        newPreviewView.addGestureRecognizer(panPreview)
         
         let cameraRoll = returnContentsOfDocumentsDirectory()
         let latestItemInCameraRoll = String(cameraRoll.last!)
@@ -44,11 +56,10 @@ class PreviewViewController: UIViewController {
 //            let imageView = UIImageView(image: mirrorImage)
             
             imageView.frame = self.view.bounds
-            previewView.addSubview(imageView)
+            newPreviewView.addSubview(imageView)
             
         } else if latestFileFileExtension == ".mov" {
             
-            let playerLayer = AVPlayerLayer()
             playerLayer.frame = view.bounds
             
             let URL = NSURL(fileURLWithPath: filePath)
@@ -60,7 +71,7 @@ class PreviewViewController: UIViewController {
             playerLayer.player = player
             playerLayer.backgroundColor = UIColor.clearColor().CGColor
             playerLayer.videoGravity = AVLayerVideoGravityResize
-            previewView.layer.addSublayer(playerLayer)
+            newPreviewView.layer.addSublayer(playerLayer)
             player.play()
             
             NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerDidReachEndNotificationHandler:", name: "AVPlayerItemDidPlayToEndTimeNotification", object: player.currentItem)
@@ -80,26 +91,27 @@ class PreviewViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-    @IBAction func panPreviewView(sender: UIPanGestureRecognizer) {
+    
+    func onPanPreview(sender: UIScreenEdgePanGestureRecognizer) {
         
         let translation = sender.translationInView(view)
         let velocity = sender.velocityInView(view)
         
         if sender.state == .Began {
             view.backgroundColor = UIColor.clearColor()
-            previewView.backgroundColor = UIColor.clearColor()
+            newPreviewView.backgroundColor = UIColor.clearColor()
             
             blackView.frame = self.view.bounds
             view.insertSubview(blackView, atIndex: 0)
         }
         if sender.state == .Changed {
             
-            previewView.frame.origin.x = translation.x
-            previewView.frame.origin.y = translation.y
+            newPreviewView.frame.origin.x = translation.x
+            newPreviewView.frame.origin.y = translation.y
             
             let rotation = convertValue(translation.x, r1Min: 0, r1Max: view.frame.width, r2Min: 0, r2Max: 10)
 
-            previewView.transform = CGAffineTransformMakeDegreeRotation(rotation)
+            newPreviewView.transform = CGAffineTransformMakeDegreeRotation(rotation)
             
             let makeTransparentOnPan = convertValue(abs(translation.y), r1Min: (view.frame.height / 8), r1Max: (view.frame.height / 2), r2Min: 0.8, r2Max: 0)
             
@@ -122,22 +134,27 @@ class PreviewViewController: UIViewController {
             if velocity.y > 2000 || translation.y > (view.frame.height / 2) {
                 print("Delete Yo")
                 
-                let cameraRoll = returnContentsOfDocumentsDirectory()
-                let latestFileName = cameraRoll.last!.lastPathComponent!
-                removeItemFromDocumentsDirectory(latestFileName)
-                
                 UIView.animateWithDuration(dismissDuration, animations: { () -> Void in
                     
-                    self.previewView.frame.origin.y = self.view.frame.height * 1.3
-                    self.previewView.frame.origin.x += moveX
+                    self.newPreviewView.frame.origin.y = self.view.frame.height * 1.3
+                    self.newPreviewView.frame.origin.x += moveX
                     self.view.backgroundColor = UIColor(red: 1, green: 0, blue: 0, alpha: 1)
                     
                     }, completion: { (Bool) -> Void in
                         
-                        // Need to delete the latest file here
-                        self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                        // Delete latest file.
+                        let cameraRoll = returnContentsOfDocumentsDirectory()
+                        let latestFileName = cameraRoll.last!.lastPathComponent!
+                        removeItemFromDocumentsDirectory(latestFileName)
                         
                         delay(0.1) {
+                            self.player.pause()
+                            self.playerLayer.removeFromSuperlayer()
+                            self.newPreviewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                            self.newPreviewView.subviews.forEach({ $0.removeFromSuperview() })
+                            self.newPreviewView.removeFromSuperview()
+                            self.blackView.removeFromSuperview()
+                            self.view.backgroundColor = UIColor.clearColor()
                             self.view.removeFromSuperview()
                         }
                 })
@@ -147,15 +164,20 @@ class PreviewViewController: UIViewController {
                 
                 UIView.animateWithDuration(dismissDuration, animations: { () -> Void in
                     
-                    self.previewView.frame.origin.y = (self.view.frame.height * 1.3) * -1
-                    self.previewView.frame.origin.x += moveX
+                    self.newPreviewView.frame.origin.y = (self.view.frame.height * 1.3) * -1
+                    self.newPreviewView.frame.origin.x += moveX
                     self.view.backgroundColor = UIColor(red: 98/255, green: 217/255, blue: 98/255, alpha: 1)
                     
                     }, completion: { (Bool) -> Void in
                         
-                        self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                        
                         delay(0.1) {
+                            self.player.pause()
+                            self.playerLayer.removeFromSuperlayer()
+                            self.newPreviewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                            self.newPreviewView.subviews.forEach({ $0.removeFromSuperview() })
+                            self.newPreviewView.removeFromSuperview()
+                            self.blackView.removeFromSuperview()
+                            self.view.backgroundColor = UIColor.clearColor()
                             self.view.removeFromSuperview()
                         }
                 })
@@ -163,9 +185,9 @@ class PreviewViewController: UIViewController {
             } else {
                 UIView.animateWithDuration(0.3, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 10, options: [], animations: { () -> Void in
                     
-                    self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                    self.previewView.frame.origin.x = 0
-                    self.previewView.frame.origin.y = 0
+                    self.newPreviewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                    self.newPreviewView.frame.origin.x = 0
+                    self.newPreviewView.frame.origin.y = 0
                     
                     }, completion: { (Bool) -> Void in
                         

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -103,7 +103,7 @@ class PreviewViewController: UIViewController {
             
             let makeTransparentOnPan = convertValue(abs(translation.y), r1Min: (view.frame.height / 8), r1Max: (view.frame.height / 2), r2Min: 0.8, r2Max: 0)
             
-            let makeOpaqueOnPan = convertValue(abs(translation.y), r1Min: (view.frame.height / 8), r1Max: (view.frame.height / 2), r2Min: 0, r2Max: 1)
+            let makeOpaqueOnPan = convertValue(abs(translation.y), r1Min: (view.frame.height / 8), r1Max: (view.frame.height / 3) * 2, r2Min: 0, r2Max: 1)
             
             blackView.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: makeTransparentOnPan)
             


### PR DESCRIPTION
Turns out that removing a view from a superview doesn't actually destroy everything inside it. Just kind of hides it.

So now I'm destroying everything (I think) in the Preview VC after accept/dismiss. Which means I need to also create all UI in code so I can rebuild it again on next preview. Seems wack but ¯_(ツ)_/¯.
