### PR TITLE
Mute Switch Be My Friend

### DIFF
--- a/Camera.xcodeproj/project.pbxproj
+++ b/Camera.xcodeproj/project.pbxproj
@@ -68,12 +68,12 @@
 		C21477BD1BEE9FE7001474A4 /* Camera */ = {
 			isa = PBXGroup;
 			children = (
-				CAF6569E1BF7C02A00B0E42F /* EditClipViewController.swift */,
 				C21477BE1BEE9FE7001474A4 /* AppDelegate.swift */,
 				C21477C01BEE9FE7001474A4 /* CameraViewController.swift */,
-				C21477C21BEE9FE7001474A4 /* Main.storyboard */,
-				61CFADB01BFE3FFB0029E4EC /* SceneTableViewCell.swift */,
 				C278C95E1BF846C800285CDF /* PreviewViewController.swift */,
+				C21477C21BEE9FE7001474A4 /* Main.storyboard */,
+				CAF6569E1BF7C02A00B0E42F /* EditClipViewController.swift */,
+				61CFADB01BFE3FFB0029E4EC /* SceneTableViewCell.swift */,
 				616937DE1BF64AEA00B47C38 /* ListViewViewController.swift */,
 				C21477D01BEFE7BB001474A4 /* Common.swift */,
 				CA2E6EBC1BFAD034007AA957 /* example_recording.mov */,
@@ -117,7 +117,7 @@
 				TargetAttributes = {
 					C21477BA1BEE9FE7001474A4 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = FG8F72SY67;
+						DevelopmentTeam = 7JJG8MJLCH;
 					};
 				};
 			};
@@ -281,7 +281,7 @@
 				INFOPLIST_FILE = Camera/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = benashman.Camera;
+				PRODUCT_BUNDLE_IDENTIFIER = andytaylor.Camera;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -296,7 +296,7 @@
 				INFOPLIST_FILE = Camera/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = benashman.Camera;
+				PRODUCT_BUNDLE_IDENTIFIER = andytaylor.Camera;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};

--- a/Camera/AppDelegate.swift
+++ b/Camera/AppDelegate.swift
@@ -21,10 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         do {
             try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
             try AVAudioSession.sharedInstance().setActive(true)
-            
-        } catch let error as NSError {
-            print(error)
-        }
+        } catch let error as NSError { print(error) }
         
         return true
     }

--- a/Camera/AppDelegate.swift
+++ b/Camera/AppDelegate.swift
@@ -18,12 +18,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "routeChanged", name: AVAudioSessionRouteChangeNotification, object: nil)
+        
         do {
             try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
             try AVAudioSession.sharedInstance().setActive(true)
         } catch let error as NSError { print(error) }
         
         return true
+    }
+    
+    func routeChanged() {
+        print(AVAudioSession.sharedInstance().category)
     }
     
     func applicationWillResignActive(application: UIApplication) {

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -40,14 +40,15 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     func restartMicAfterDismissingPreview() {
 
 //        print("Mic input \(micInput!)")
-        
-        do {
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
-            try AVAudioSession.sharedInstance().setActive(true)
-        } catch let error as NSError { print(error) }
-        
-        captureSession.automaticallyConfiguresApplicationAudioSession = false
-        captureSession.addInput(micInput!)
+        if microphone != nil {
+            do {
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch let error as NSError { print(error) }
+            
+            captureSession.automaticallyConfiguresApplicationAudioSession = false
+            captureSession.addInput(micInput!)
+        }
 
 //        print("Inputs \(captureSession.inputs)")
     }

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -99,6 +99,10 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         previewLayer?.removeFromSuperlayer()
         captureSession.stopRunning()
         captureSession = AVCaptureSession()
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryAmbient)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch let error as NSError { print(error) }
     }
     
     func beginSession(device: AVCaptureDevice) {
@@ -106,6 +110,9 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         do {
             captureSession.addInput(try AVCaptureDeviceInput(device: device))
             captureSession.automaticallyConfiguresApplicationAudioSession = false
+            
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
+            try AVAudioSession.sharedInstance().setActive(true)
             
             previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
             self.cameraView.layer.addSublayer(previewLayer!)
@@ -187,6 +194,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             
             }) { (Bool) -> Void in
         }
+        
+        endSession()
         
         videoOutput.stopRecording()
     }

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -52,6 +52,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         if microphone != nil {
             do {
                 captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
+                captureSession.usesApplicationAudioSession = true
             } catch { }
         }
         

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -27,6 +27,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     var frontCamera: AVCaptureDevice?
     var microphone: AVCaptureDevice?
     
+    var micInput: AVCaptureDeviceInput?
+    
     let stillImageOutput = AVCaptureStillImageOutput()
     let videoOutput = AVCaptureMovieFileOutput()
     let devices = AVCaptureDevice.devices()
@@ -39,15 +41,32 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
 //        endSession()
 //        beginSession(backCamera!)
 
-        print(captureSession.inputs)
-        print(AVAudioSession.sharedInstance().category)
-        captureSession.automaticallyConfiguresApplicationAudioSession = false
-        
+        print("Mic input \(micInput!)")
         
         do {
             try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
             try AVAudioSession.sharedInstance().setActive(true)
         } catch let error as NSError { print(error) }
+        
+        captureSession.automaticallyConfiguresApplicationAudioSession = false
+        captureSession.addInput(micInput!)
+
+        print("Inputs \(captureSession.inputs)")
+        
+//        do {
+//            micInput = try AVCaptureDeviceInput(device: microphone)
+//            captureSession.addInput(micInput)
+//        } catch {}
+
+//        print(captureSession.inputs)
+//        print(AVAudioSession.sharedInstance().category)
+//        captureSession.automaticallyConfiguresApplicationAudioSession = false
+//        captureSession.usesApplicationAudioSession = true
+        
+//        do {
+//            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
+//            try AVAudioSession.sharedInstance().setActive(true)
+//        } catch let error as NSError { print(error) }
         
         print(AVAudioSession.sharedInstance().category)
         
@@ -76,7 +95,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         
         if microphone != nil {
             do {
-                captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
+                micInput = try AVCaptureDeviceInput(device: microphone)
+                captureSession.addInput(micInput)
                 captureSession.usesApplicationAudioSession = true
             } catch { }
         }
@@ -212,14 +232,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         }
         
         videoOutput.stopRecording()
-        
-        if microphone != nil {
-            do {
-                captureSession.removeInput(try AVCaptureDeviceInput(device: microphone))
-                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryAmbient)
-                try AVAudioSession.sharedInstance().setActive(true)
-            } catch let error as NSError { print(error) }
-        }
     }
     
     func takeStillImage() {
@@ -247,6 +259,18 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         }
     }
     
+    func removeMic() {
+        if microphone != nil {
+            do {
+                captureSession.removeInput(micInput)
+                print("is it here? \(captureSession.inputs)")
+                
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryAmbient)
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch let error as NSError { print(error) }
+        }
+    }
+    
     @IBAction func longPressWholeView(sender: UILongPressGestureRecognizer) {
         if sender.state == .Began {
             startRecording()
@@ -255,7 +279,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             
         }
         if sender.state == .Ended {
-            self.stopRecording()
+            stopRecording()
+            removeMic()
         }
     }
     
@@ -277,7 +302,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
 
         }
         if sender.state == .Ended {
-            self.stopRecording()
+            stopRecording()
+            removeMic()
         }
     }
     

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -13,7 +13,7 @@ import AVFoundation
 
 class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelegate {
     
-    var previewViewController: UIViewController!
+    var previewViewController: PreviewViewController!
     
     @IBOutlet weak var cameraView: UIView!
     @IBOutlet weak var recordButton: UIButton!
@@ -34,13 +34,26 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     override func prefersStatusBarHidden() -> Bool {
         return true
     }
+    
+    func restartMicAfterDismissingPreview() {
+//        endSession()
+//        beginSession(backCamera!)
+
+//        if microphone != nil {
+//            do {
+//                captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
+//                captureSession.usesApplicationAudioSession = true
+//            } catch { }
+//        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         
-        previewViewController = storyboard.instantiateViewControllerWithIdentifier("PreviewViewController")
+        previewViewController = storyboard.instantiateViewControllerWithIdentifier("PreviewViewController") as! PreviewViewController
+        previewViewController.cameraViewController = self
         
         setupCamera()
         setButtonLabel()
@@ -214,8 +227,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
                 let outputPath = "\(documentsPath)/\(currentTimeStamp()).jpg"
                 
                 imageData.writeToFile(outputPath, atomically: true)
-                
-                self.previewViewController.willMoveToParentViewController(self)
+
+                self.addChildViewController(self.previewViewController)
                 self.view.addSubview(self.previewViewController.view)
                 self.previewViewController.didMoveToParentViewController(self)
             }
@@ -264,7 +277,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     
     func captureOutput(captureOutput: AVCaptureFileOutput!, didFinishRecordingToOutputFileAtURL outputFileURL: NSURL!, fromConnections connections: [AnyObject]!, error: NSError!) {
         
-        self.previewViewController.willMoveToParentViewController(self)
+        addChildViewController(previewViewController)
         self.view.addSubview(self.previewViewController.view)
         self.previewViewController.didMoveToParentViewController(self)
     }

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -39,6 +39,18 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
 //        endSession()
 //        beginSession(backCamera!)
 
+        print(captureSession.inputs)
+        print(AVAudioSession.sharedInstance().category)
+        captureSession.automaticallyConfiguresApplicationAudioSession = false
+        
+        
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch let error as NSError { print(error) }
+        
+        print(AVAudioSession.sharedInstance().category)
+        
 //        if microphone != nil {
 //            do {
 //                captureSession.addInput(try AVCaptureDeviceInput(device: microphone))

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -53,29 +53,9 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
 
         print("Inputs \(captureSession.inputs)")
         
-//        do {
-//            micInput = try AVCaptureDeviceInput(device: microphone)
-//            captureSession.addInput(micInput)
-//        } catch {}
-
-//        print(captureSession.inputs)
 //        print(AVAudioSession.sharedInstance().category)
-//        captureSession.automaticallyConfiguresApplicationAudioSession = false
 //        captureSession.usesApplicationAudioSession = true
         
-//        do {
-//            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
-//            try AVAudioSession.sharedInstance().setActive(true)
-//        } catch let error as NSError { print(error) }
-        
-        print(AVAudioSession.sharedInstance().category)
-        
-//        if microphone != nil {
-//            do {
-//                captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
-//                captureSession.usesApplicationAudioSession = true
-//            } catch { }
-//        }
     }
 
     override func viewDidLoad() {

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -99,10 +99,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         previewLayer?.removeFromSuperlayer()
         captureSession.stopRunning()
         captureSession = AVCaptureSession()
-        do {
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryAmbient)
-            try AVAudioSession.sharedInstance().setActive(true)
-        } catch let error as NSError { print(error) }
     }
     
     func beginSession(device: AVCaptureDevice) {
@@ -110,9 +106,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         do {
             captureSession.addInput(try AVCaptureDeviceInput(device: device))
             captureSession.automaticallyConfiguresApplicationAudioSession = false
-            
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
-            try AVAudioSession.sharedInstance().setActive(true)
             
             previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
             self.cameraView.layer.addSublayer(previewLayer!)
@@ -127,10 +120,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
                 captureSession.addOutput(videoOutput)
             }
             
-        } catch let err as NSError {
-            print(err)
-        }
-        
+        } catch let err as NSError { print(err) }
     }
     
     func switchCameras() {
@@ -195,9 +185,15 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             }) { (Bool) -> Void in
         }
         
-        endSession()
-        
         videoOutput.stopRecording()
+        
+        if microphone != nil {
+            do {
+                captureSession.removeInput(try AVCaptureDeviceInput(device: microphone))
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryAmbient)
+                try AVAudioSession.sharedInstance().setActive(true)
+            } catch let error as NSError { print(error) }
+        }
     }
     
     func takeStillImage() {

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -38,10 +38,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     }
     
     func restartMicAfterDismissingPreview() {
-//        endSession()
-//        beginSession(backCamera!)
 
-        print("Mic input \(micInput!)")
+//        print("Mic input \(micInput!)")
         
         do {
             try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
@@ -51,11 +49,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         captureSession.automaticallyConfiguresApplicationAudioSession = false
         captureSession.addInput(micInput!)
 
-        print("Inputs \(captureSession.inputs)")
-        
-//        print(AVAudioSession.sharedInstance().category)
-//        captureSession.usesApplicationAudioSession = true
-        
+//        print("Inputs \(captureSession.inputs)")
     }
 
     override func viewDidLoad() {

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -27,7 +27,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     var backCamera: AVCaptureDevice?
     var frontCamera: AVCaptureDevice?
     var microphone: AVCaptureDevice?
-    
     var micInput: AVCaptureDeviceInput?
     
     let stillImageOutput = AVCaptureStillImageOutput()
@@ -155,9 +154,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             endSession()
             beginSession(frontCamera!)
             if microphone != nil {
-                do {
-                    captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
-                } catch { }
+                captureSession.addInput(micInput)
             }
             usingbackCamera = false
             setButtonLabel()
@@ -165,9 +162,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             endSession()
             beginSession(backCamera!)
             if microphone != nil {
-                do {
-                    captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
-                } catch { }
+                captureSession.addInput(micInput)
             }
             usingbackCamera = true
             setButtonLabel()

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -14,6 +14,8 @@ class PreviewViewController: UIViewController {
 
     @IBOutlet weak var previewView: UIView!
     
+    var latestFileFileExtension: String!
+    
     var cameraViewController: CameraViewController!
     
     let blackView = UIView()
@@ -39,7 +41,7 @@ class PreviewViewController: UIViewController {
         
         // Dis string bullshit to get file type
         let latestFileFileExtensionIndex = latestItemInCameraRoll.endIndex.advancedBy(-4)
-        let latestFileFileExtension = latestItemInCameraRoll[Range(start: latestFileFileExtensionIndex, end: latestItemInCameraRoll.endIndex)]
+        latestFileFileExtension = latestItemInCameraRoll[Range(start: latestFileFileExtensionIndex, end: latestItemInCameraRoll.endIndex)]
         
         if latestFileFileExtension == ".jpg" {
             
@@ -152,7 +154,9 @@ class PreviewViewController: UIViewController {
                         self.previewView.subviews.forEach({ $0.removeFromSuperview() })
                         self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
                         self.blackView.removeFromSuperview()
-                        self.cameraViewController.restartMicAfterDismissingPreview()
+                        if self.latestFileFileExtension == ".mov" {
+                            self.cameraViewController.restartMicAfterDismissingPreview()
+                        }
                         self.view.removeFromSuperview()
                 })
                 
@@ -172,7 +176,9 @@ class PreviewViewController: UIViewController {
                         self.previewView.subviews.forEach({ $0.removeFromSuperview() })
                         self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
                         self.blackView.removeFromSuperview()
-                        self.cameraViewController.restartMicAfterDismissingPreview()
+                        if self.latestFileFileExtension == ".mov" {
+                            self.cameraViewController.restartMicAfterDismissingPreview()
+                        }
                         self.view.removeFromSuperview()
                 })
                 

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -14,6 +14,8 @@ class PreviewViewController: UIViewController {
 
     @IBOutlet weak var previewView: UIView!
     
+    var cameraViewController: CameraViewController!
+    
     let blackView = UIView()
     
     var player = AVPlayer()
@@ -166,6 +168,8 @@ class PreviewViewController: UIViewController {
                     self.view.backgroundColor = UIColor(red: 98/255, green: 217/255, blue: 98/255, alpha: 1)
                     
                     }, completion: { (Bool) -> Void in
+                        
+                        self.cameraViewController.restartMicAfterDismissingPreview()
                         
                         delay(0.1) {
                             self.playerLayer.removeFromSuperlayer()

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -169,15 +169,15 @@ class PreviewViewController: UIViewController {
                     
                     }, completion: { (Bool) -> Void in
                         
-                        self.cameraViewController.restartMicAfterDismissingPreview()
-                        
                         delay(0.1) {
                             self.playerLayer.removeFromSuperlayer()
                             self.previewView.subviews.forEach({ $0.removeFromSuperview() })
                             self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
                             self.blackView.removeFromSuperview()
+                            self.cameraViewController.restartMicAfterDismissingPreview()
                             self.view.removeFromSuperview()
                         }
+                        
                 })
                 
             } else {

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -148,13 +148,12 @@ class PreviewViewController: UIViewController {
                         let latestFileName = cameraRoll.last!.lastPathComponent!
                         removeItemFromDocumentsDirectory(latestFileName)
                         
-                        delay(0.1) {
-                            self.playerLayer.removeFromSuperlayer()
-                            self.previewView.subviews.forEach({ $0.removeFromSuperview() })
-                            self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                            self.blackView.removeFromSuperview()
-                            self.view.removeFromSuperview()
-                        }
+                        self.playerLayer.removeFromSuperlayer()
+                        self.previewView.subviews.forEach({ $0.removeFromSuperview() })
+                        self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                        self.blackView.removeFromSuperview()
+                        self.cameraViewController.restartMicAfterDismissingPreview()
+                        self.view.removeFromSuperview()
                 })
                 
             } else if velocity.y < -2000 || translation.y < (view.frame.height / 2) * -1 {
@@ -169,15 +168,12 @@ class PreviewViewController: UIViewController {
                     
                     }, completion: { (Bool) -> Void in
                         
-                        delay(0.1) {
-                            self.playerLayer.removeFromSuperlayer()
-                            self.previewView.subviews.forEach({ $0.removeFromSuperview() })
-                            self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
-                            self.blackView.removeFromSuperview()
-                            self.cameraViewController.restartMicAfterDismissingPreview()
-                            self.view.removeFromSuperview()
-                        }
-                        
+                        self.playerLayer.removeFromSuperlayer()
+                        self.previewView.subviews.forEach({ $0.removeFromSuperview() })
+                        self.previewView.transform = CGAffineTransformMakeDegreeRotation(0)
+                        self.blackView.removeFromSuperview()
+                        self.cameraViewController.restartMicAfterDismissingPreview()
+                        self.view.removeFromSuperview()
                 })
                 
             } else {


### PR DESCRIPTION
When the recording stops, I'm basically removing the audio input and setting the AVAudioSession to ambient. This honors the mute switch. I need to work out how to add the mic back when the preview is dismissed but the idea is right.

Basically with this code, but I'm not sure how to trigger it:

``` swift
if microphone != nil {
    do {
        captureSession.addInput(try AVCaptureDeviceInput(device: microphone))
        captureSession.usesApplicationAudioSession = true
    } catch { }
}
```

At the moment you can record with audio for the first recording of the session.
