### PR TITLE
Video and Audio Stuff

### DIFF
--- a/Camera/AppDelegate.swift
+++ b/Camera/AppDelegate.swift
@@ -20,11 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "routeChanged", name: AVAudioSessionRouteChangeNotification, object: nil)
         
-        do {
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
-            try AVAudioSession.sharedInstance().setActive(true)
-        } catch let error as NSError { print(error) }
-        
         // Create clips directory for future use
         
         let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0] as NSString

--- a/Camera/AppDelegate.swift
+++ b/Camera/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "routeChanged", name: AVAudioSessionRouteChangeNotification, object: nil)
         
+        
+        
         // Create clips directory for future use
         
         let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0] as NSString

--- a/Camera/AppDelegate.swift
+++ b/Camera/AppDelegate.swift
@@ -20,7 +20,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "routeChanged", name: AVAudioSessionRouteChangeNotification, object: nil)
         
-        
+        do {
+            try AVAudioSession.sharedInstance().setActive(false)
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch let error as NSError { print(error) }
         
         // Create clips directory for future use
         

--- a/Camera/Base.lproj/Main.storyboard
+++ b/Camera/Base.lproj/Main.storyboard
@@ -77,7 +77,7 @@
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lx0-SS-lNg">
                                 <rect key="frame" x="227" y="544" width="147" height="80"/>
                                 <animations/>
-                                <fontDescription key="fontDescription" type="system" pointSize="42"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                 <state key="normal" title="👉">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
@@ -212,7 +212,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mMT-IG-lwV" id="PD9-Fq-uJI">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="87.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="SCENE #" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DmA-8b-rkA">

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -124,8 +124,14 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
-        
-//        cameraView.alpha = 0
+    }
+    
+    func appWillEnterBackground() {
+        cameraView.alpha = 0
+    }
+    
+    func appDidEnterForeground() {
+        cameraView.alpha = 1
     }
     
     override func viewWillAppear(animated: Bool) {
@@ -137,8 +143,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
-        
-//        cameraView.alpha = 1
     }
     
     override func viewDidDisappear(animated: Bool) {
@@ -157,12 +161,16 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appWillEnterBackground", name: UIApplicationWillResignActiveNotification, object: nil)
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appDidEnterForeground", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "runWhenDeletedAllClips", name: "All Clips Deleted", object: nil)
+        
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         
         previewViewController = storyboard.instantiateViewControllerWithIdentifier("PreviewViewController") as! PreviewViewController
         previewViewController.cameraViewController = self
-        
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "runWhenDeletedAllClips", name: "All Clips Deleted", object: nil)
         
         progressBar.alpha = 0
         progressBar.progress = 0
@@ -178,7 +186,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         if microphone != nil {
             do {
                 micInput = try AVCaptureDeviceInput(device: microphone)
-//                captureSession.usesApplicationAudioSession = true
             } catch { }
         }
         

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -56,7 +56,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
                 doneButton.alpha = 0
                 doneButton.setTitle("", forState: UIControlState.Normal)
             } else {
-                doneButton.setTitle("\(clipCount)", forState: UIControlState.Normal)
+                doneButton.setTitle(totalTimeInSeconds, forState: UIControlState.Normal)
                 doneButton.alpha = 1
             }
         }
@@ -118,6 +118,8 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     }
     
     func updateButtonCount() {
+        updateTotalTime()
+        
         let realm = try! Realm()
         clipCount = realm.objects(Clip).count
     }
@@ -170,6 +172,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         setupCamera()
         setCameraOrientationButtonLabel()
         setSoundButtonLabel()
+        updateButtonCount()
         
         if backCamera != nil {
             beginSession(backCamera!)

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -101,11 +101,13 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
             let priority = DISPATCH_QUEUE_PRIORITY_DEFAULT
             dispatch_async(dispatch_get_global_queue(priority, 0)) {
                 
-                do {
-                    try AVAudioSession.sharedInstance().setActive(false)
-                    try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
-                    try AVAudioSession.sharedInstance().setActive(true)
-                } catch let error as NSError { print(error) }
+                if AVAudioSession.sharedInstance().category != AVAudioSessionCategoryPlayAndRecord {
+                    do {
+                        try AVAudioSession.sharedInstance().setActive(false)
+                        try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: [.MixWithOthers, .AllowBluetooth, .DefaultToSpeaker])
+                        try AVAudioSession.sharedInstance().setActive(true)
+                    } catch let error as NSError { print(error) }
+                }
                 
                 self.captureSession.automaticallyConfiguresApplicationAudioSession = false
                 self.captureSession.addInput(self.micInput!)

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -122,10 +122,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         clipCount = realm.objects(Clip).count
     }
     
-    override func viewWillDisappear(animated: Bool) {
-        super.viewWillDisappear(animated)
-    }
-    
     func appWillEnterBackground() {
         cameraView.alpha = 0
     }

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -122,11 +122,19 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         clipCount = realm.objects(Clip).count
     }
     
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+//        cameraView.alpha = 0
+    }
+    
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         
         startMic()
         updateButtonCount()
+        
+//        cameraView.alpha = 1
     }
     
     override func viewDidDisappear(animated: Bool) {
@@ -166,7 +174,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         if microphone != nil {
             do {
                 micInput = try AVCaptureDeviceInput(device: microphone)
-                captureSession.usesApplicationAudioSession = true
+//                captureSession.usesApplicationAudioSession = true
             } catch { }
         }
         

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -137,10 +137,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         updateButtonCount()
     }
     
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-    }
-    
     override func viewDidDisappear(animated: Bool) {
         super.viewDidDisappear(animated)
         

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -133,6 +133,10 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         
         startMic()
         updateButtonCount()
+    }
+    
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
         
 //        cameraView.alpha = 1
     }

--- a/Camera/EditClipViewController.swift
+++ b/Camera/EditClipViewController.swift
@@ -46,6 +46,10 @@ class EditClipViewController: UIViewController, UITextFieldDelegate, UIGestureRe
         // Register for keyboard events
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShow:", name: UIKeyboardWillChangeFrameNotification, object: nil)
         
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appWillEnterBackground", name: UIApplicationWillResignActiveNotification, object: nil)
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appDidEnterForeground", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        
         // Set up UI
         overlayView.backgroundColor = UIColor.clearColor()
         setUpTextInput()
@@ -56,6 +60,14 @@ class EditClipViewController: UIViewController, UITextFieldDelegate, UIGestureRe
         
         drawingViewController = storyboard.instantiateViewControllerWithIdentifier("DrawingViewController") as! DrawingViewController
         drawingViewController.editClipViewController = self
+    }
+    
+    func appWillEnterBackground() {
+        player.pause()
+    }
+    
+    func appDidEnterForeground() {
+        player.play()
     }
     
     override func viewWillAppear(animated: Bool) {

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -205,9 +205,6 @@ class PreviewViewController: UIViewController {
                         try! realm.write {
                             realm.delete(self.clip)
                         }
-//                        delay(0.25) {
-//                            self.cameraViewController.updateButtonCount()
-//                        }
                 })
                 
             } else if velocity.y < -2000 || translation.y < (view.frame.height / 2) * -1 {

--- a/Camera/PreviewViewController.swift
+++ b/Camera/PreviewViewController.swift
@@ -32,6 +32,10 @@ class PreviewViewController: UIViewController {
     
     override func viewWillAppear(animated: Bool) {
         
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appWillEnterBackground", name: UIApplicationWillResignActiveNotification, object: nil)
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "appDidEnterForeground", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        
         let realm = try! Realm()
         clip = realm.objects(Clip).last!
         
@@ -85,6 +89,14 @@ class PreviewViewController: UIViewController {
     func playerDidReachEndNotificationHandler(notification: NSNotification) {
         let playerItem = notification.object as! AVPlayerItem
         playerItem.seekToTime(kCMTimeZero)
+    }
+    
+    func appWillEnterBackground() {
+        player.pause()
+    }
+    
+    func appDidEnterForeground() {
+        player.play()
     }
 
     override func didReceiveMemoryWarning() {

--- a/Camera/VideoProcessing.swift
+++ b/Camera/VideoProcessing.swift
@@ -12,6 +12,22 @@ import AVFoundation
 import Photos
 import RealmSwift
 
+var totalTimeInSeconds: String = ""
+
+func updateTotalTime() {
+    let realm = try! Realm()
+    let clips = realm.objects(Clip).sorted("filename", ascending: true)
+
+    var totesTimeDub: Double = 0
+    
+    for clip in clips {
+        let duration = AVURLAsset(URL: NSURL(fileURLWithPath: getAbsolutePathForFile(clip.filename))).duration
+        totesTimeDub += round(CMTimeGetSeconds(duration))
+        
+        totalTimeInSeconds = String(Int(totesTimeDub)) + "s"
+    }
+}
+
 func exportVideo() {
     let composition = AVMutableComposition()
     let trackVideo:AVMutableCompositionTrack = composition.addMutableTrackWithMediaType(AVMediaTypeVideo, preferredTrackID: CMPersistentTrackID())


### PR DESCRIPTION
- When you backgrounded the app it was freeze framing what was in the viewfinder and showing that the next time you opened the app. It wasn't very noticeable if you opened it again straight away but hours later it was weird. Fixes #41 
- Don't start the mic twice on app load.
- Pause/Play playing video when backgrounding and foregrounding app Fixes #71
- Show total seconds instead of clip count. Fixes #56 
