### PR TITLE
Remove Recording Delay for Profit

### DIFF
--- a/Camera/Base.lproj/Main.storyboard
+++ b/Camera/Base.lproj/Main.storyboard
@@ -27,13 +27,6 @@
                                     <outletCollection property="gestureRecognizers" destination="Ock-s3-pv7" appends="YES" id="6d2-6A-8dY"/>
                                 </connections>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keeeeeep" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="goi-cw-hF3">
-                                <rect key="frame" x="149" y="323" width="77" height="21"/>
-                                <animations/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-DT-yf2">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="2"/>
                                 <animations/>
@@ -46,6 +39,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gZq-S3-fWn">
                                 <rect key="frame" x="0.0" y="20" width="375" height="42"/>
                                 <animations/>
+                                <gestureRecognizers/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="23q-Ef-G1f"/>
                                 </constraints>
@@ -126,9 +120,6 @@
                             <constraint firstAttribute="trailing" secondItem="OOk-t2-LFN" secondAttribute="trailing" id="yko-nb-poL"/>
                         </constraints>
                         <variation key="default">
-                            <mask key="subviews">
-                                <exclude reference="goi-cw-hF3"/>
-                            </mask>
                             <mask key="constraints">
                                 <exclude reference="Gzr-pg-JfX"/>
                                 <exclude reference="iaZ-eT-BRh"/>
@@ -150,12 +141,12 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
-                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="H7V-co-Tg3" userLabel="Long Press Record Button">
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.0" id="H7V-co-Tg3" userLabel="Long Press Record Button">
                     <connections>
                         <action selector="longPressButton:" destination="BYZ-38-t0r" id="6OW-RO-Frd"/>
                     </connections>
                 </pongPressGestureRecognizer>
-                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="fi7-FT-psy" userLabel="Long Press Whole View">
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.0" id="fi7-FT-psy" userLabel="Long Press Whole View">
                     <connections>
                         <action selector="longPressWholeView:" destination="BYZ-38-t0r" id="IEM-v1-i5C"/>
                     </connections>

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -440,9 +440,10 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         clip.filename = outputFileURL.lastPathComponent!
         clip.type = "video"
         
-        print(timerProgress)
         if timerProgress < 0.03 {
-            toastWithMessage("Hold Anywhere to Record", appendTo: self.view, timeShownInSeconds: 1, style: .Neutral)
+            delay(0.3) {
+                toastWithMessage("Hold Anywhere to Record", appendTo: self.view, timeShownInSeconds: 1, style: .Neutral)
+            }
             showIcons()
             deleteClip(clip.filename)
             recordButton.alpha = 1

--- a/Camera/CameraViewController.swift
+++ b/Camera/CameraViewController.swift
@@ -322,9 +322,7 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
     func stopRecording() {
         print("Stop Recording")
         
-        // Stop Timer
         progressBar.alpha = 0
-        timer.invalidate()
         
         recordButton.layer.borderColor = UIColor.whiteColor().colorWithAlphaComponent(0.5).CGColor
         recordButton.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.2)
@@ -428,11 +426,6 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         }
     }
     
-    @IBAction func tapButton(sender: AnyObject) {
-//        takeStillImage()
-        toastWithMessage("Hold Anywhere to Record", appendTo: self.view, timeShownInSeconds: 1, style: .Neutral)
-    }
-    
     func showVideoPreview() {
         addChildViewController(previewViewController)
         self.view.addSubview(self.previewViewController.view)
@@ -447,12 +440,23 @@ class CameraViewController: UIViewController, AVCaptureFileOutputRecordingDelega
         clip.filename = outputFileURL.lastPathComponent!
         clip.type = "video"
         
-        let realm = try! Realm()
-        try! realm.write {
-            realm.add(clip)
+        print(timerProgress)
+        if timerProgress < 0.03 {
+            toastWithMessage("Hold Anywhere to Record", appendTo: self.view, timeShownInSeconds: 1, style: .Neutral)
+            showIcons()
+            deleteClip(clip.filename)
+            recordButton.alpha = 1
+            if clipCount != 0 {
+                totalTimeLabel.alpha = 1
+            }
+        } else {
+            let realm = try! Realm()
+            try! realm.write {
+                realm.add(clip)
+            }
+            showVideoPreview()
         }
-        
-        showVideoPreview()
+        timer.invalidate()
     }
 }
 

--- a/Camera/Common.swift
+++ b/Camera/Common.swift
@@ -67,3 +67,7 @@ func getAbsolutePathForFile(filename: String) -> String {
     
     return path
 }
+
+func roundToOneDecimalPlace(float: Double) -> Double {
+    return round(float * 10) / 10
+}

--- a/Camera/ListViewViewController.swift
+++ b/Camera/ListViewViewController.swift
@@ -80,7 +80,7 @@ class ListViewViewController: UIViewController, UITableViewDataSource, UITableVi
         }
         
         let clipDuration = clipAsset.duration
-        let clipDurationInSeconds = Int(round(CMTimeGetSeconds(clipDuration)))
+        let clipDurationInSeconds = roundToOneDecimalPlace(CMTimeGetSeconds(clipDuration))
         let clipDurationSuffix: String!
         if clipDurationInSeconds == 1 {
             clipDurationSuffix = "Second"

--- a/Camera/Toasts.swift
+++ b/Camera/Toasts.swift
@@ -16,7 +16,6 @@ enum ToastStyle {
 }
 
 func toastWithMessage(message: String, appendTo: UIView, timeShownInSeconds: Double = 1.5, style: ToastStyle = .Positive, accomodateStatusBar: Bool = false) {
-    print(message)
     
     // Setup
     let padding: CGFloat = 15


### PR DESCRIPTION
By default, the long press gesture has a 300ms delay before firing. This is so single taps can be recognized. We don't really _need_ single taps on the camera screen. All single tapping the camera did was show a message to 'Hold Anywhere to Record'.

The benefit is recording starts fucking fast—instantly.
- [x] remove swipe to switch cameras
