### PR TITLE
Export Safely

### DIFF
--- a/Camera/VideoProcessing.swift
+++ b/Camera/VideoProcessing.swift
@@ -62,15 +62,27 @@ func exportVideo() {
         let tracks = sourceAsset.tracksWithMediaType(AVMediaTypeVideo)
         let audios = sourceAsset.tracksWithMediaType(AVMediaTypeAudio)
         
+        print("Video Tracks: \(tracks.count)")
+        print("Audio Tracks: \(audios.count)")
+        
         if tracks.count > 0 {
-            let assetTrack:AVAssetTrack = tracks[0] as AVAssetTrack
-            let assetTrackAudio:AVAssetTrack = audios[0] as AVAssetTrack
-            do {
-                try trackVideo.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrack, atTime: insertTime)
-                try trackAudio.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrackAudio, atTime: insertTime)
-            } catch { }
-            
-            insertTime = CMTimeAdd(insertTime, sourceAsset.duration)
+            if audios.count > 0 {
+                let assetTrack:AVAssetTrack = tracks[0] as AVAssetTrack
+                let assetTrackAudio:AVAssetTrack = audios[0] as AVAssetTrack
+                do {
+                    try trackVideo.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrack, atTime: insertTime)
+                    try trackAudio.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrackAudio, atTime: insertTime)
+                } catch { }
+                
+                insertTime = CMTimeAdd(insertTime, sourceAsset.duration)
+            } else {
+                let assetTrack:AVAssetTrack = tracks[0] as AVAssetTrack
+                do {
+                    try trackVideo.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrack, atTime: insertTime)
+                } catch { }
+                
+                insertTime = CMTimeAdd(insertTime, sourceAsset.duration)
+            }
         }
     }
     

--- a/Camera/VideoProcessing.swift
+++ b/Camera/VideoProcessing.swift
@@ -62,9 +62,6 @@ func exportVideo() {
         let tracks = sourceAsset.tracksWithMediaType(AVMediaTypeVideo)
         let audios = sourceAsset.tracksWithMediaType(AVMediaTypeAudio)
         
-        print("Video Tracks: \(tracks.count)")
-        print("Audio Tracks: \(audios.count)")
-        
         if tracks.count > 0 {
             if audios.count > 0 {
                 let assetTrack:AVAssetTrack = tracks[0] as AVAssetTrack
@@ -73,16 +70,14 @@ func exportVideo() {
                     try trackVideo.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrack, atTime: insertTime)
                     try trackAudio.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrackAudio, atTime: insertTime)
                 } catch { }
-                
-                insertTime = CMTimeAdd(insertTime, sourceAsset.duration)
             } else {
                 let assetTrack:AVAssetTrack = tracks[0] as AVAssetTrack
                 do {
                     try trackVideo.insertTimeRange(CMTimeRangeMake(kCMTimeZero,sourceAsset.duration), ofTrack: assetTrack, atTime: insertTime)
                 } catch { }
-                
-                insertTime = CMTimeAdd(insertTime, sourceAsset.duration)
             }
+            
+            insertTime = CMTimeAdd(insertTime, sourceAsset.duration)
         }
     }
     


### PR DESCRIPTION
This fixes #112 

It's documented there but basically if the clip didn't have audio the export exploded. This will happen when the mic fails to get added again—something that shouldn't happen but does occasionally.

It's just safer anyway. If we let you remove audio from clips in the future then it's required.
